### PR TITLE
Added element.setConstraint method

### DIFF
--- a/svg.draggable.js
+++ b/svg.draggable.js
@@ -150,6 +150,12 @@ SVG.extend(SVG.Element, {
       return element
     }
     
+    /* Sets new constraint on the element */
+		element.setConstraint = function(newConstraint){
+			constraint = newConstraint || {};
+		}
+
+    
     return this
   }
   


### PR DESCRIPTION
This method sets a new constraint on an item, which might be useful in certain user scenarios, for example if a new x or y drag constraint must be set on the element as the drag is started (this is the case in case of our software).