### PR TITLE
Fixed errors, updated callback handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,20 @@ rect.draggable(function (x, y, elem) {
 });
 ```
 
+With this you can also easily achieve some snapping functionality:
+
+```javascript
+var snapRange = 50;
+rect.draggable(function (x, y, elem) {
+	var res = {};
+	
+	res.x = x - (x % snapRange);
+	res.y = y - (y % snapRange);
+	
+	return res;
+});
+```
+
 
 ## Remove
 The draggable functionality van be removed with the `fixed()` method:

--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ rect.beforestart = function(event) {
 }
 ```
 
-The `dragstart`, `dragmove` and `dragend` callbacks will pass the delta values as an object in the first argument and the event as the second:
+The `dragstart`, `dragmove` and `dragend` callbacks will pass the delta values (also containing an object holding the absolute coordinates) as an object in the first argument and the event as the second:
 
 ```javascript
 rect.dragmove = function(delta, event) {
-  console.log(delta.x, delta.y)
+  console.log(delta.x, delta.y, delta.coord.x, delta.coord.y)
 }
 ```
 
@@ -61,7 +61,7 @@ Instead of calling draggable() with an object you might also call it with a func
 The following example will prevent the rectangle from "crossing the imaginary border" at x = 300:
 
 ```javascript
-rect.draggable(function (x, y) {
+rect.draggable(function (x, y, elem) {
 	var res = {x: x, y: y};
 	
 	if (x > 300) {

--- a/svg.draggable.js
+++ b/svg.draggable.js
@@ -106,7 +106,7 @@ SVG.extend(SVG.Element, {
         
         /* move the element to its new position, if possible by constraint*/
         if (typeof constraint == "function") {
-          var coord = constraint(x, y)
+          var coord = constraint(x, y, element)
           var xTo = element.x()
           var yTo = element.y()
 
@@ -140,7 +140,7 @@ SVG.extend(SVG.Element, {
           /* invoke any callbacks */
           if (element.dragmove) {
             delta.x = x - element.startPosition.x
-            delta.y = y - elemen.startPosition.y
+            delta.y = y - element.startPosition.y
             delta.coord = {
               x: x,
               y: y

--- a/svg.draggable.js
+++ b/svg.draggable.js
@@ -162,7 +162,7 @@ SVG.extend(SVG.Element, {
         coord: {
           x: element.x(),
           y: element.y()
-        }
+        },
         zoom: element.startPosition.zoom
       }
       

--- a/svg.draggable.js
+++ b/svg.draggable.js
@@ -107,32 +107,47 @@ SVG.extend(SVG.Element, {
         /* move the element to its new position, if possible by constraint*/
         if (typeof constraint == "function") {
           var coord = constraint(x, y)
+          var xTo = element.x()
+          var yTo = element.y()
 
           if (typeof coord.x == "boolean") {
             if (coord.x) {
-              element.x(x)
+              xTo = x
             }
           }
           else if (typeof coord.x == "number") {
-            element.x(coord.x)
+            xTo = coord.x
           }
 
           if (typeof coord.y == "boolean") {
             if (coord.y) {
-              element.y(y)
+              yTo = y
             }
           }
           else if (typeof coord.y == "number") {
-            element.y(coord.y)
+            yTo = coord.y
           }
+          
+          move(xTo, yTo)
         }
         else if (typeof constraint == "object") {
-          element.move(x, y)          
+          move(x, y)          
         }
 
-        /* invoke any callbacks */
-        if (element.dragmove)
-          element.dragmove(delta, event)
+        function move(x, y) {
+          element.move(x, y)
+
+          /* invoke any callbacks */
+          if (element.dragmove) {
+            delta.x = x - element.startPosition.x
+            delta.y = y - elemen.startPosition.y
+            delta.coord = {
+              x: x,
+              y: y
+            }
+            element.dragmove(delta, event)
+          }
+        }
       }
     }
     
@@ -142,8 +157,12 @@ SVG.extend(SVG.Element, {
       
       /* calculate move position */
       var delta = {
-        x:    event.pageX - element.startEvent.pageX,
-        y:    event.pageY - element.startEvent.pageY,
+        x: element.x() - element.startPosition.x,
+        y: element.y() - element.startPosition.y,
+        coord: {
+          x: element.x(),
+          y: element.y()
+        }
         zoom: element.startPosition.zoom
       }
       

--- a/svg.draggable.js
+++ b/svg.draggable.js
@@ -108,13 +108,22 @@ SVG.extend(SVG.Element, {
         if (typeof constraint == "function") {
           var coord = constraint(x, y)
 
-          if (typeof coord == "object") {
-            element.move(coord.x, coord.y)
-          }
-          else if (typeof coord == "boolean") {
-            if (coord) {
-              move(x, y)
+          if (typeof coord.x == "boolean") {
+            if (coord.x) {
+              element.x(x)
             }
+          }
+          else if (typeof coord.x == "number") {
+            element.x(coord.x)
+          }
+
+          if (typeof coord.y == "boolean") {
+            if (coord.y) {
+              element.y(y)
+            }
+          }
+          else if (typeof coord.y == "number") {
+            element.y(coord.y)
           }
         }
         else if (typeof constraint == "object") {


### PR DESCRIPTION
Updated the callback handling; before the delta object given to the callbacks just ignored that the element itself might not have been moved do to constraints (object or newly implemented function), it just contained information about where the element would be without constraints.
This pull request should fix all other errors too.
I also updated the README according to callback handling.