### PR TITLE
Fix(svg parent): svg.js no longer has .parent but was changed to pare…

### DIFF
--- a/svg.draggable.js
+++ b/svg.draggable.js
@@ -9,7 +9,7 @@
     draggable: function(constraint) {
       var start, drag, end
         , element = this
-        , parent  = this.parent._parent(SVG.Nested) || this._parent(SVG.Doc)
+        , parent  = this.parent(SVG.Nested) || this.parent(SVG.Doc)
       
       /* remove draggable if already present */
       if (typeof this.fixed === 'function')


### PR DESCRIPTION
…nt()